### PR TITLE
set default kernel through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ One notable feature of C# scripting is the ability to specify a return value for
 
 ### *Code in F#*
 
-You can also start up the REPL in F# mode:
+You can also start up the REPL in F# mode with `--default-kernel` or set the environment variable `DOTNET_REPL_DEFAULT_KERNEL` to `fsharp`:
 
 ```console
 > dotnet repl --default-kernel fsharp
+```
+```console
+# DOTNET_REPL_DEFAULT_KERNEL=fsharp
+> dotnet repl
 ```
 
 <img src="https://user-images.githubusercontent.com/547415/121456837-8d9cc300-c95b-11eb-9a91-1daae2dbc655.png" width="60%" />

--- a/src/dotnet-repl/CommandLineParser.cs
+++ b/src/dotnet-repl/CommandLineParser.cs
@@ -23,11 +23,12 @@ namespace dotnet_repl
         public static Option<string> DefaultKernelOption = new Option<string>(
             "--default-kernel",
             description: "The default language for the kernel",
-            getDefaultValue: () => "csharp").FromAmong(
-            "csharp",
-            "fsharp",
-            "pwsh",
-            "sql");
+            getDefaultValue: () => Environment.GetEnvironmentVariable("DOTNET_REPL_DEFAULT_KERNEL") ?? "csharp"
+            ).FromAmong(
+                "csharp",
+                "fsharp",
+                "pwsh",
+                "sql");
 
         public static Option<FileInfo> NotebookOption = new Option<FileInfo>(
                 "--notebook",


### PR DESCRIPTION
Being an F# fan this would be cool to have and seemed simple to implement. Inspired by the `DOTNET_NEW_PREFERRED_LANG` option for `dotnet new`.