### PR TITLE
Basic command line parameterization for notebook automation

### DIFF
--- a/src/dotnet-repl.Tests/dotnet-repl.Tests.v3.ncrunchproject
+++ b/src/dotnet-repl.Tests/dotnet-repl.Tests.v3.ncrunchproject
@@ -5,6 +5,9 @@
       <NamedTestSelector>
         <TestName>dotnet_repl.Tests.Automation.NotebookAutomationTests.Notebook_runner_produces_expected_output</TestName>
       </NamedTestSelector>
+      <NamedTestSelector>
+        <TestName>dotnet_repl.Tests.Automation.NotebookRunnerTests.Notebook_runner_produces_expected_output</TestName>
+      </NamedTestSelector>
     </IgnoredTests>
   </Settings>
 </ProjectConfiguration>

--- a/src/dotnet-repl/DocumentParser.cs
+++ b/src/dotnet-repl/DocumentParser.cs
@@ -6,18 +6,37 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Documents;
 using Microsoft.DotNet.Interactive.Documents.Jupyter;
+using KernelInfo = Microsoft.DotNet.Interactive.Documents.KernelInfo;
 
 namespace dotnet_repl;
 
 public static class DocumentParser
 {
-    public static async Task<InteractiveDocument> ReadFileAsInteractiveDocument(
+    public static async Task<InteractiveDocument> LoadInteractiveDocumentAsync(
         FileInfo file,
         CompositeKernel kernel)
     {
-        await using var stream = file.OpenRead();
+        var kernelInfos = CreateKernelInfos(kernel);
+        return await LoadInteractiveDocumentAsync(file, kernelInfos);
+    }
 
-        KernelNameCollection kernelNames = new();
+    public static async Task<InteractiveDocument> LoadInteractiveDocumentAsync(
+        FileInfo file, 
+        KernelInfoCollection kernelInfos)
+    {
+        var fileContents = await File.ReadAllTextAsync(file.FullName);
+
+        return file.Extension.ToLowerInvariant() switch
+        {
+            ".ipynb" => Notebook.Parse(fileContents, kernelInfos),
+            ".dib" => CodeSubmission.Parse(fileContents, kernelInfos),
+            _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {file.Extension}"),
+        };
+    }
+
+    public static KernelInfoCollection CreateKernelInfos(this CompositeKernel kernel)
+    {
+        KernelInfoCollection kernelInfos = new();
 
         var kernelChoosers = kernel.Directives.OfType<ChooseKernelDirective>();
 
@@ -25,21 +44,14 @@ public static class DocumentParser
         {
             List<string> kernelAliases = new();
 
-            foreach (var alias in kernelChooser.Aliases)
+            foreach (var alias in kernelChooser.Aliases.Where(a => a != kernelChooser.Name))
             {
                 kernelAliases.Add(alias[2..]);
             }
 
-            kernelNames.Add(new KernelName(kernelChooser.Name[2..], kernelAliases));
+            kernelInfos.Add(new KernelInfo(kernelChooser.Name[2..], kernelAliases));
         }
 
-        var notebook = file.Extension.ToLowerInvariant() switch
-        {
-            ".ipynb" => await Notebook.ReadAsync(stream, kernelNames),
-            ".dib" => await CodeSubmission.ReadAsync(stream, "csharp", kernelNames),
-            _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {file.Extension}"),
-        };
-
-        return notebook;
+        return kernelInfos;
     }
 }

--- a/src/dotnet-repl/InputKernel.cs
+++ b/src/dotnet-repl/InputKernel.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.DotNet.Interactive;
+using Microsoft.DotNet.Interactive.Commands;
+using Microsoft.DotNet.Interactive.Events;
+using Spectre.Console;
+
+namespace dotnet_repl;
+
+public class InputKernel : Kernel, IKernelCommandHandler<RequestInput>
+{
+    public InputKernel() : base("ask", null, null)
+    {
+    }
+
+    public Task HandleAsync(RequestInput command, KernelInvocationContext context)
+    {
+        switch (command.InputTypeHint)
+        {
+            default:
+                var value = AnsiConsole.Ask<string>($"Please provide a value for {command.Prompt}");
+
+                if (value is { })
+                {
+                    context.Publish(new InputProduced(value, command));
+                }
+
+                break;
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/dotnet-repl/KernelBuilder.cs
+++ b/src/dotnet-repl/KernelBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Interactive;
@@ -90,6 +91,16 @@ public static class KernelBuilder
         compositeKernel.Add(new MarkdownKernel());
         compositeKernel.Add(new SqlDiscoverabilityKernel());
         compositeKernel.Add(new KqlDiscoverabilityKernel());
+        
+        var inputKernel = new InputKernel();
+        // inputKernel.RegisterCommandHandler<RequestInput>(async (input, context) =>
+        // {
+        //     Console.WriteLine("hi!");
+        // });
+        compositeKernel.Add(inputKernel);
+        compositeKernel.SetDefaultTargetKernelNameForCommand(
+            typeof(RequestInput), 
+            inputKernel.Name);
 
         compositeKernel.DefaultKernelName = options.DefaultKernelName;
 

--- a/src/dotnet-repl/KeyBindings.cs
+++ b/src/dotnet-repl/KeyBindings.cs
@@ -29,6 +29,11 @@ internal static class KeyBindings
         editor.KeyBindings.Add(
             ConsoleKey.C,
             ConsoleModifiers.Control,
+            () => new Clear());
+
+        editor.KeyBindings.Add(
+            ConsoleKey.D,
+            ConsoleModifiers.Control,
             () => new Quit(repl.QuitAction));
 
         editor.KeyBindings.Add<Clear>(

--- a/src/dotnet-repl/Properties/launchSettings.json
+++ b/src/dotnet-repl/Properties/launchSettings.json
@@ -6,7 +6,7 @@
     },
     "run and exit, .trx": {
       "commandName": "Project",
-      "commandLineArgs": "--notebook \"C:\\dev\\interactive\\samples\\Notebooks\\csharp\\Samples\\DataFrame-Getting Started.ipynb\" --output-format trx --output-path c:\\temp\\automation\\DataFrame-output.trx --exit-after-run"
+      "commandLineArgs": "--notebook \"C:\\temp\\automation\\parameterized.dib\" --output-format ipynb --output-path c:\\temp\\automation\\parameterized.dib.vsoutput.ipynb --exit-after-run --input y=\"oh hey there!\""
     },
     "REPL": {
       "commandName": "Project"

--- a/src/dotnet-repl/SpectreHelpBuilder.cs
+++ b/src/dotnet-repl/SpectreHelpBuilder.cs
@@ -15,6 +15,12 @@ internal class SpectreHelpBuilder : HelpBuilder
 
     private IEnumerable<HelpSectionDelegate> GetLayout(HelpContext context)
     {
+        if (context.ParseResult.Errors.Any())
+        {
+            // don't show help on error
+            yield break;
+        }
+
         var console = AnsiConsole.Create(new AnsiConsoleSettings
         {
             Ansi = AnsiSupport.Yes,

--- a/src/dotnet-repl/StartupOptions.cs
+++ b/src/dotnet-repl/StartupOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace dotnet_repl;
 
@@ -11,7 +12,8 @@ public class StartupOptions
         DirectoryInfo? logPath = null,
         bool exitAfterRun = false,
         OutputFormat outputFormat = OutputFormat.ipynb,
-        FileInfo? outputPath = null)
+        FileInfo? outputPath = null,
+        IDictionary<string, string>? inputs = null)
     {
         DefaultKernelName = defaultKernel;
         WorkingDir = workingDir ?? new DirectoryInfo(Directory.GetCurrentDirectory());
@@ -20,6 +22,7 @@ public class StartupOptions
         ExitAfterRun = exitAfterRun;
         OutputFormat = outputFormat;
         OutputPath = outputPath;
+        Inputs = inputs;
     }
 
     public DirectoryInfo? LogPath { get; }
@@ -28,13 +31,14 @@ public class StartupOptions
 
     public DirectoryInfo WorkingDir { get; }
 
-    public FileInfo? Notebook { get; }
+    public FileInfo? Notebook { get; set; }
 
-    public bool ExitAfterRun { get; }
+    public bool ExitAfterRun { get; set; }
 
     public OutputFormat OutputFormat { get; }
 
     public FileInfo? OutputPath { get; }
+    public IDictionary<string, string>? Inputs { get; set; }
 
     public bool IsAutomationMode => ExitAfterRun || OutputPath is { };
 }

--- a/src/dotnet-repl/StartupOptionsBinder.cs
+++ b/src/dotnet-repl/StartupOptionsBinder.cs
@@ -1,4 +1,5 @@
-﻿using System.CommandLine;
+﻿using System.Collections.Generic;
+using System.CommandLine;
 using System.CommandLine.Binding;
 using System.IO;
 
@@ -13,6 +14,7 @@ internal class StartupOptionsBinder : BinderBase<StartupOptions>
     private readonly Option<bool> _exitAfterRun;
     private readonly Option<OutputFormat> _outputFormat;
     private readonly Option<FileInfo> _outputPath;
+    private readonly Option<IDictionary<string, string>> _inputs;
 
     public StartupOptionsBinder(
         Option<string> defaultKernelOption,
@@ -21,7 +23,8 @@ internal class StartupOptionsBinder : BinderBase<StartupOptions>
         Option<DirectoryInfo> logPathOption,
         Option<bool> exitAfterRun,
         Option<OutputFormat> outputFormat,
-        Option<FileInfo> outputPath)
+        Option<FileInfo> outputPath,
+        Option<IDictionary<string, string>> inputs)
     {
         _defaultKernelOption = defaultKernelOption;
         _workingDirOption = workingDirOption;
@@ -30,6 +33,7 @@ internal class StartupOptionsBinder : BinderBase<StartupOptions>
         _exitAfterRun = exitAfterRun;
         _outputFormat = outputFormat;
         _outputPath = outputPath;
+        _inputs = inputs;
     }
 
     protected override StartupOptions GetBoundValue(BindingContext bindingContext)
@@ -41,6 +45,7 @@ internal class StartupOptionsBinder : BinderBase<StartupOptions>
             bindingContext.ParseResult.GetValueForOption(_logPathOption),
             bindingContext.ParseResult.GetValueForOption(_exitAfterRun),
             bindingContext.ParseResult.GetValueForOption(_outputFormat),
-            bindingContext.ParseResult.GetValueForOption(_outputPath));
+            bindingContext.ParseResult.GetValueForOption(_outputPath),
+            bindingContext.ParseResult.GetValueForOption(_inputs));
     }
 }

--- a/src/dotnet-repl/dotnet-repl.csproj
+++ b/src/dotnet-repl/dotnet-repl.csproj
@@ -25,16 +25,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22451.3" />
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22451.3" />
-    <PackageReference Include="Microsoft.DotNet.Interactive.Documents" Version="1.0.0-beta.22451.3" />
-    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.22451.3" />
-    <PackageReference Include="Microsoft.Dotnet.Interactive.Browser" Version="1.0.0-beta.22451.3" />
-    <PackageReference Include="microsoft.dotnet.interactive.powershell" Version="1.0.0-beta.22451.3" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22471.1" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22471.1" />
+    <PackageReference Include="Microsoft.DotNet.Interactive.Documents" Version="1.0.0-beta.22471.1" />
+    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.22471.1" />
+    <PackageReference Include="Microsoft.Dotnet.Interactive.Browser" Version="1.0.0-beta.22471.1" />
+    <PackageReference Include="microsoft.dotnet.interactive.powershell" Version="1.0.0-beta.22471.1" />
     <PackageReference Include="radline" Version="0.6.0" />
     <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9" />
     <PackageReference Include="system.reactive" Version="5.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.44.1-preview.0.42" />
+    <PackageReference Include="Spectre.Console" Version="0.45.1-preview.0.8" />
     <PackageReference Include="trexlib" Version="1.0.188" />
     <PackageReference Include="pocket.disposable" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/dotnet-repl/dotnet-repl.csproj
+++ b/src/dotnet-repl/dotnet-repl.csproj
@@ -25,16 +25,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22427.2" />
-    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22427.2" />
-    <PackageReference Include="Microsoft.DotNet.Interactive.Documents" Version="1.0.0-beta.22427.2" />
-    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.22427.2" />
-    <PackageReference Include="Microsoft.Dotnet.Interactive.Browser" Version="1.0.0-beta.22427.2" />
-    <PackageReference Include="microsoft.dotnet.interactive.powershell" Version="1.0.0-beta.22427.2" />
+    <PackageReference Include="microsoft.dotnet.interactive" Version="1.0.0-beta.22451.3" />
+    <PackageReference Include="microsoft.dotnet.interactive.csharp" Version="1.0.0-beta.22451.3" />
+    <PackageReference Include="Microsoft.DotNet.Interactive.Documents" Version="1.0.0-beta.22451.3" />
+    <PackageReference Include="microsoft.dotnet.interactive.fsharp" Version="1.0.0-beta.22451.3" />
+    <PackageReference Include="Microsoft.Dotnet.Interactive.Browser" Version="1.0.0-beta.22451.3" />
+    <PackageReference Include="microsoft.dotnet.interactive.powershell" Version="1.0.0-beta.22451.3" />
     <PackageReference Include="radline" Version="0.6.0" />
     <PackageReference Include="Serilog.Sinks.RollingFileAlternate" Version="2.0.9" />
     <PackageReference Include="system.reactive" Version="5.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.44.1-preview.0.34" />
+    <PackageReference Include="Spectre.Console" Version="0.44.1-preview.0.42" />
     <PackageReference Include="trexlib" Version="1.0.188" />
     <PackageReference Include="pocket.disposable" Version="1.1.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This is still very early but here's what it looks like as of this PR.

Parameter values can be passed to a notebook during automation runs using any number of `--input key=value` options.

<img width="1914" alt="image" src="https://user-images.githubusercontent.com/547415/191785826-f7322b44-9aa2-4e70-b72a-77877c69cd64.png">

It also seems useful to be able to discover parameters (e.g. `@input:`-prefixed magic command tokens) from the command line:

<img width="951" alt="image" src="https://user-images.githubusercontent.com/547415/191786571-37239549-f0b1-4437-8c8b-98af17e2b5e2.png">