### PR TITLE
add support for `#!import`, additional importable and runnable file types

### DIFF
--- a/src/dotnet-repl.Tests/Automation/NotebookRunnerTests.cs
+++ b/src/dotnet-repl.Tests/Automation/NotebookRunnerTests.cs
@@ -50,7 +50,7 @@ public class NotebookRunnerTests : IDisposable
     [Fact]
     public async Task When_an_ipynb_is_run_and_no_error_is_produced_then_the_exit_code_is_0()
     {
-        var result = await _parser.InvokeAsync($"--notebook \"{_directory}/succeed.ipynb\" --exit-after-run", console);
+        var result = await _parser.InvokeAsync($"--run \"{_directory}/succeed.ipynb\" --exit-after-run", console);
 
         console.Error.ToString().Should().BeEmpty();
         result.Should().Be(0);
@@ -59,7 +59,7 @@ public class NotebookRunnerTests : IDisposable
     [Fact]
     public async Task When_an_ipynb_is_run_and_an_error_is_produced_from_a_cell_then_the_exit_code_is_2()
     {
-        var result = await _parser.InvokeAsync($"--notebook \"{_directory}/fail.ipynb\" --exit-after-run", console);
+        var result = await _parser.InvokeAsync($"--run \"{_directory}/fail.ipynb\" --exit-after-run", console);
 
         console.Error.ToString().Should().BeEmpty();
         result.Should().Be(2);

--- a/src/dotnet-repl/AnsiConsoleExtensions.cs
+++ b/src/dotnet-repl/AnsiConsoleExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Text;
+using Microsoft.DotNet.Interactive;
 using Microsoft.DotNet.Interactive.Events;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -138,7 +139,7 @@ internal static class AnsiConsoleExtensions
 
     private static Markup GetMarkup(DisplayEvent @event)
     {
-        var formattedValue = @event.FormattedValues.First();
+        var formattedValue = @event.FormattedValues.FirstOrDefault() ?? new FormattedValue("text/plain", "");
 
         var markup = formattedValue.MimeType switch
         {

--- a/src/dotnet-repl/CommandLineParser.cs
+++ b/src/dotnet-repl/CommandLineParser.cs
@@ -33,12 +33,11 @@ public static class CommandLineParser
             "fsharp",
             "pwsh",
             "javascript",
-            "html",
-            "sql");
+            "html");
 
-    public static Option<FileInfo> NotebookOption = new Option<FileInfo>(
-            "--notebook",
-            description: "Run all of the cells in the specified notebook file")
+    public static Option<FileInfo> RunOption = new Option<FileInfo>(
+            "--run",
+            description: "Run all of the code in the specified notebook, source code, or script file. To exit when done, set the --exit-after-run option.")
         {
             ArgumentHelpName = "PATH"
         }
@@ -46,7 +45,7 @@ public static class CommandLineParser
 
     public static Option<bool> ExitAfterRunOption = new(
         "--exit-after-run",
-        $"Exit after the file specified by {NotebookOption.Aliases.First()} has run");
+        $"Exit after the file specified by {RunOption.Aliases.First()} has run");
 
     public static Option<DirectoryInfo> WorkingDirOption = new Option<DirectoryInfo>(
             "--working-dir",
@@ -82,7 +81,7 @@ public static class CommandLineParser
 
     public static Option<OutputFormat> OutputFormatOption = new(
         "--output-format",
-        description: $"The output format to be used when running a notebook with the {NotebookOption.Aliases.First()} and {ExitAfterRunOption.Aliases.First()} options",
+        description: $"The output format to be used when running a notebook with the {RunOption.Aliases.First()} and {ExitAfterRunOption.Aliases.First()} options",
         getDefaultValue: () => OutputFormat.ipynb);
 
     public static Parser Create(
@@ -94,7 +93,7 @@ public static class CommandLineParser
         {
             LogPathOption,
             DefaultKernelOption,
-            NotebookOption,
+            RunOption,
             WorkingDirOption,
             ExitAfterRunOption,
             OutputFormatOption,
@@ -115,7 +114,7 @@ public static class CommandLineParser
             new StartupOptionsBinder(
                 DefaultKernelOption,
                 WorkingDirOption,
-                NotebookOption,
+                RunOption,
                 LogPathOption,
                 ExitAfterRunOption,
                 OutputFormatOption,
@@ -140,7 +139,7 @@ public static class CommandLineParser
 
             var outputFormatOption = new Option<OutputFormat>(
                 "--output-format",
-                description: $"The output format to be used when running a notebook with the {NotebookOption.Aliases.First()} and {ExitAfterRunOption.Aliases.First()} options",
+                description: $"The output format to be used when running a notebook with the {RunOption.Aliases.First()} and {ExitAfterRunOption.Aliases.First()} options",
                 getDefaultValue: () => OutputFormat.ipynb);
 
             var command = new Command("convert")
@@ -252,7 +251,7 @@ public static class CommandLineParser
             if (notebook is null)
             {
                 // TODO: (StartAsync) move this validation to the parser configuration
-                ansiConsole.WriteLine($"Option {ExitAfterRunOption.Aliases.First()} option cannot be used without also specifying the {NotebookOption.Aliases.First()} option.");
+                ansiConsole.WriteLine($"Option {ExitAfterRunOption.Aliases.First()} option cannot be used without also specifying the {RunOption.Aliases.First()} option.");
                 return disposables;
             }
 

--- a/src/dotnet-repl/DocumentParser.cs
+++ b/src/dotnet-repl/DocumentParser.cs
@@ -36,6 +36,8 @@ public static class DocumentParser
             ".fs" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "fsharp") },
             ".fsx" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "fsharp") },
             ".ps1" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "pwsh") },
+            ".html" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "html") },
+            ".js" => new InteractiveDocument { new InteractiveDocumentElement(fileContents, "javascript") },
             
             _ => throw new InvalidOperationException($"Unrecognized extension for a notebook: {file.Extension}"),
         };

--- a/src/dotnet-repl/KernelBuilder.cs
+++ b/src/dotnet-repl/KernelBuilder.cs
@@ -28,8 +28,9 @@ public static class KernelBuilder
 
         var compositeKernel = new CompositeKernel()
                               .UseAboutMagicCommand()
-                              .UseDebugDirective()
+                              .UseDebugMagicCommand()
                               .UseHelpMagicCommand()
+                              .UseImportMagicCommand()
                               .UseQuitCommand();
 
         compositeKernel.AddMiddleware(async (command, context, next) =>

--- a/src/dotnet-repl/Properties/launchSettings.json
+++ b/src/dotnet-repl/Properties/launchSettings.json
@@ -6,10 +6,14 @@
     },
     "run and exit, .trx": {
       "commandName": "Project",
-      "commandLineArgs": "--notebook \"C:\\temp\\automation\\parameterized.dib\" --output-format ipynb --output-path c:\\temp\\automation\\parameterized.dib.vsoutput.ipynb --exit-after-run --input y=\"oh hey there!\""
+      "commandLineArgs": "--run \"C:\\temp\\automation\\parameterized.dib\" --output-format ipynb --output-path c:\\temp\\automation\\parameterized.dib.vsoutput.ipynb --exit-after-run --input y=\"oh hey there!\""
     },
     "REPL": {
       "commandName": "Project"
+    },
+    "REPL with --run": {
+      "commandName": "Project",
+      "commandLineArgs": "--run c:\\temp\\automation\\github.html"
     }
   }
 }


### PR DESCRIPTION
This adds a few more file types supported for command line automation, and brings in support for the `#!import` magic command for all of the same file types. 

In light of these file types, the command line option `--notebook` makes less sense, so it's been renamed to `--run`. 