### PR TITLE
Set roll-forward policy to `LatestMajor` for the global tool.

### DIFF
--- a/src/dotnet-repl/dotnet-repl.csproj
+++ b/src/dotnet-repl/dotnet-repl.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
On a clean system, installing .NET 8 and then dotnet-repl gets you the following:

```
You must install or update .NET to run this application.

App: /home/alexrp/.dotnet/tools/dotnet-repl
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '7.0.0' (x64)
.NET location: /home/alexrp/.dotnet

The following frameworks were found:
  8.0.1 at [/home/alexrp/.dotnet/shared/Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=x64&rid=linux-x64&os=ubuntu.23.10
```

Seems sensible to just set a roll-forward policy like this.